### PR TITLE
Updates Dashboards to have a custom label instead of using auto

### DIFF
--- a/monitoring/dashboards/common-metrics.json
+++ b/monitoring/dashboards/common-metrics.json
@@ -101,7 +101,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "eigen_performance_score,
+          "expr": "eigen_performance_score",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,

--- a/monitoring/dashboards/common-metrics.json
+++ b/monitoring/dashboards/common-metrics.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 13,
+  "id": 8,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -45,7 +45,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -90,7 +90,6 @@
           "values": false
         },
         "textMode": "auto",
-        "wideLayout": true
       },
       "pluginVersion": "10.2.3",
       "targets": [
@@ -102,7 +101,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "eigen_performance_score{avs_name=\"$AvsName\"}",
+          "expr": "eigen_performance_score,
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -117,7 +116,10 @@
       "type": "stat"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "The performance metric is a score between 0 and 100 and each developer can define their own way of calculating the score. The score is calculated based on the performance of the Node and the performance of the backing services.",
       "fieldConfig": {
         "defaults": {
@@ -159,8 +161,6 @@
       },
       "id": 8,
       "options": {
-        "minVizHeight": 200,
-        "minVizWidth": 200,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -195,7 +195,10 @@
       "type": "gauge"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -306,7 +309,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "The total balance in AVS Node per used token.",
       "fieldConfig": {
@@ -515,7 +518,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "Average Response Time per method in seconds over time.",
       "fieldConfig": {
@@ -612,7 +615,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Total of JSON-RPC requests per method.",
       "fieldConfig": {
         "defaults": {
@@ -704,7 +710,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Request duration distribution in seconds per method.",
       "fieldConfig": {
         "defaults": {
@@ -806,7 +815,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values({job=\"eigenDA\"},avs_name)",
+          "query": "label_values(avs_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -825,6 +834,6 @@
   "timezone": "",
   "title": "AVS Specification Metrics",
   "uid": "l8RpPN94z",
-  "version": 2,
+  "version": 12,
   "weekStart": ""
 }

--- a/monitoring/dashboards/common-metrics.json
+++ b/monitoring/dashboards/common-metrics.json
@@ -89,7 +89,7 @@
           "fields": "/^avs_name$/",
           "values": false
         },
-        "textMode": "auto",
+        "textMode": "auto"
       },
       "pluginVersion": "10.2.3",
       "targets": [

--- a/monitoring/dashboards/common-metrics.json
+++ b/monitoring/dashboards/common-metrics.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 8,
+  "id": 13,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -45,7 +45,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
         "defaults": {
@@ -89,9 +89,10 @@
           "fields": "/^avs_name$/",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.1",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -101,7 +102,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "eigen_performance_score",
+          "expr": "eigen_performance_score{avs_name=\"$AvsName\"}",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -116,10 +117,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "description": "The performance metric is a score between 0 and 100 and each developer can define their own way of calculating the score. The score is calculated based on the performance of the Node and the performance of the backing services.",
       "fieldConfig": {
         "defaults": {
@@ -161,6 +159,8 @@
       },
       "id": 8,
       "options": {
+        "minVizHeight": 200,
+        "minVizWidth": 200,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -170,9 +170,10 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "10.1.1",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -194,16 +195,14 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -305,7 +304,10 @@
       "type": "row"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The total balance in AVS Node per used token.",
       "fieldConfig": {
         "defaults": {
@@ -344,9 +346,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.1",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -408,9 +411,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.1",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -471,9 +475,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.1",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -510,7 +515,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "description": "Average Response Time per method in seconds over time.",
       "fieldConfig": {
@@ -519,6 +524,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -554,7 +560,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -592,10 +599,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(eigen_rpc_request_duration_seconds_sum{method=~\".*\", avs_name=\"$AvsName\"}[5m])",
+          "expr": "rate(eigen_rpc_request_duration_seconds_sum{method=~\".*\"}[5m])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "{{method}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -605,10 +612,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "description": "Total of JSON-RPC requests per method.",
       "fieldConfig": {
         "defaults": {
@@ -616,6 +620,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -651,7 +656,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           }
@@ -698,10 +704,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "description": "Request duration distribution in seconds per method.",
       "fieldConfig": {
         "defaults": {
@@ -723,7 +726,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -782,8 +786,7 @@
   ],
   "refresh": "",
   "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": [
@@ -793,11 +796,7 @@
           "text": "da-node",
           "value": "da-node"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "definition": "label_values(avs_name)",
+        "definition": "label_values({job=\"eigenDA\"},avs_name)",
         "description": "AVS Name",
         "hide": 0,
         "includeAll": false,
@@ -806,7 +805,8 @@
         "name": "AvsName",
         "options": [],
         "query": {
-          "query": "label_values(avs_name)",
+          "qryType": 1,
+          "query": "label_values({job=\"eigenDA\"},avs_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -825,6 +825,6 @@
   "timezone": "",
   "title": "AVS Specification Metrics",
   "uid": "l8RpPN94z",
-  "version": 12,
+  "version": 2,
   "weekStart": ""
 }

--- a/monitoring/dashboards/eigenda-metrics.json
+++ b/monitoring/dashboards/eigenda-metrics.json
@@ -18,14 +18,14 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 12,
+  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "the total number of batches processed by the DA node",
       "fieldConfig": {
@@ -143,7 +143,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "the total size of batches processed by the DA node",
       "fieldConfig": {
@@ -244,7 +244,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "the total number  of batches that have been removed by the DA node",
       "fieldConfig": {
@@ -328,7 +328,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "node_eigenda_processed_batches_total{type=\"number\"}",
+          "expr": "node_eigenda_removed_batches_total{type=\"number\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -344,7 +344,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "description": "the total size of batches that have been removed by the DA node",
       "fieldConfig": {
@@ -429,7 +429,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "node_eigenda_processed_batches_total{type=\"size\"} / 1024",
+          "expr": "node_eigenda_removed_batches_total{type=\"size\"} / 1024",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -445,7 +445,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -565,7 +565,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -662,7 +662,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -762,7 +762,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {

--- a/monitoring/dashboards/eigenda-metrics.json
+++ b/monitoring/dashboards/eigenda-metrics.json
@@ -18,14 +18,14 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 12,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "description": "the total number of batches processed by the DA node",
       "fieldConfig": {
@@ -114,7 +114,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -131,7 +131,7 @@
           "hide": true,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -143,7 +143,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "description": "the total size of batches processed by the DA node",
       "fieldConfig": {
@@ -232,7 +232,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -244,7 +244,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "description": "the total number  of batches that have been removed by the DA node",
       "fieldConfig": {
@@ -328,11 +328,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "node_eigenda_removed_batches_total{type=\"number\"}",
+          "expr": "node_eigenda_processed_batches_total{type=\"number\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -344,7 +344,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "description": "the total size of batches that have been removed by the DA node",
       "fieldConfig": {
@@ -429,11 +429,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "node_eigenda_removed_batches_total{type=\"size\"} / 1024",
+          "expr": "node_eigenda_processed_batches_total{type=\"size\"} / 1024",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -445,7 +445,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
         "defaults": {
@@ -565,7 +565,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
         "defaults": {
@@ -651,26 +651,9 @@
           "expr": "sum(node_eigenda_processed_batches_total{type=\"size\"})\n/\nsum(node_eigenda_processed_batches_total{type=\"number\"})",
           "hide": false,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "average size",
           "range": true,
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "node_eigenda_processed_batches_total{type=\"size\"}",
-          "fullMetaSearch": false,
-          "hide": true,
-          "includeNullMetadata": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
         }
       ],
       "title": "Average processed batch size",
@@ -679,7 +662,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
         "defaults": {
@@ -723,7 +706,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -766,7 +750,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -778,7 +762,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
         "defaults": {
@@ -822,7 +806,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -864,7 +849,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "node_request_latency_ms{quantile=\"0.99\", method=\"RetrieveChunks\"}",
+          "expr": "node_request_latency_ms{quantile=\"0.99\",method=\"RetrieveChunks\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -895,10 +880,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "description": "the total number of node's socket address updates",
       "fieldConfig": {
         "defaults": {
@@ -910,7 +892,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -940,9 +923,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
@@ -965,10 +949,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1011,7 +992,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1064,10 +1046,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1110,7 +1089,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1163,7 +1143,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 38,
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": []
@@ -1176,6 +1156,6 @@
   "timezone": "",
   "title": "EigenDA",
   "uid": "dcd9d495-ff1e-4794-b2b6-62634e4b40d1",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }


### PR DESCRIPTION
This improves readability by showing the relevant status instead of all the attached labels for a node. E.g: 
<img width="325" alt="image" src="https://github.com/Layr-Labs/eigenda-operator-setup/assets/17509050/8578a204-c45a-4092-8148-e6e70e280e20">
