### PR TITLE
fix: update outdated link to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Retrieval Setup:
 
 In order for users to retrieve data from your node, you will need to open access to retrieval ports. 
 
-Ensure the port specified as `NODE_RETRIEVAL_PORT` in the [.env](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/.env#L17) has open access to the public internet.
+Ensure the port specified as `NODE_RETRIEVAL_PORT` in the [.env](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/.env.example#L17) has open access to the public internet.
 
 For users with private IP e.g. connecting to the Internet via a router, you may need to perform port forwarding to open the retrieval ports. 
 Use a web browser and navigate to http://192.168.0.1 and set-up port forwarding according to instruction of your router.


### PR DESCRIPTION
Hello,
I've noticed, that .env file has been deleted a while ago. I'm fixing on of links in README to `.env.example` instead of `.env`.

@shrimalmadhur FYI