### PR TITLE
Clarifying dual quorum opt-in behavior

### DIFF
--- a/holesky/README.md
+++ b/holesky/README.md
@@ -87,6 +87,8 @@ Execute the following command based on the quorum you want to opt-in in EigenDA 
 ```
 You only need to provide the quorum which you want to opt into. For example if you are already registered to quorum `0` and want to opt-in one more quorum `1`, then you just need to set `<quorum>` as `1` while opting in again.
 
+If you attempt to opt-in to both quorums ('`0,1`') you must have sufficient TVL to opt-in to the active Operator set for both quorums, otherwise the entire opt-in attempt will fail for both quorums. The opt-in attempt for both quorums is an "all or nothing" process.
+
 > **_WARNING:_**
 Operator must wait up to 6 hours if the delegation happened after you opt-in to the EigenDA AVS. EigenLayer's AVS-Sync component runs at 6 hour batch intervals to update the delegation totals on chain for each operator. If you are unable to opt in despite having sufficient delegated stake, please wait at least 6 hours, then retry opt-in.
 


### PR DESCRIPTION
Per Slack chat with @ian-shim 

Question: If a user requests to join both quorums (0,1), but they are only approved for quorum 0, will EigenDA register them for quorum 0? Or will it fail for both? E.g. is this an "all or nothing operation"?

Answer: In that case, the entire operation would fail, and the operator doesn't get opted into any of them. They will need to retry later by specifying only one quorum that was approved or by making themselves eligible for both quorums.