### PR TITLE
add readme for using node without ecdsa key

### DIFF
--- a/holesky/README.md
+++ b/holesky/README.md
@@ -219,3 +219,16 @@ Make sure your `.env` file still has correct values in the [TODO](https://github
 ```
 docker compose up -d
 ```
+
+## Running your node without giving access to operator ECDSA keys
+In [EigenDA v0.6.1](https://github.com/Layr-Labs/eigenda-operator-setup/releases/tag/v0.6.1), we added a feature where you can configure your node so that it doesn't need operator's ECDSA keys to run.
+Your node still need access to BLS keys for attestation purposes.
+>**_NOTE:_** You still need ECDSA and BLS keys to opt-in to EigenDA.
+
+To enable this feature by using our setup, follow the below commands:
+* Remove the `"${NODE_ECDSA_KEY_FILE_HOST}:/app/operator_keys/ecdsa_key.json:readonly"` mount from `docker-compose.yml` file.
+* Update the `NODE_ECDSA_KEY_FILE` in your `.env` file to be empty.
+* Update the `NODE_ECDSA_KEY_PASSWORD` in your `.env` file to be empty.
+* Update the `NODE_PUBLIC_IP_CHECK_INTERVAL` in your `.env` file to be `0` (This flag was used to check and update your IP onchain if your IP changes, so if your IP changes it's your responsibility to update).
+* Run your node normally using the `docker compose up -d` command.
+* Opt-in to EigenDA if not already opted in.

--- a/mainnet/README.md
+++ b/mainnet/README.md
@@ -219,3 +219,16 @@ Make sure your `.env` file still has correct values in the [TODO](https://github
 ```
 docker compose up -d
 ```
+
+## Running your node without giving access to operator ECDSA keys
+In [EigenDA v0.6.1](https://github.com/Layr-Labs/eigenda-operator-setup/releases/tag/v0.6.1), we added a feature where you can configure your node so that it doesn't need operator's ECDSA keys to run. 
+Your node still need access to BLS keys for attestation purposes.
+>**_NOTE:_** You still need ECDSA and BLS keys to opt-in to EigenDA. 
+
+To enable this feature by using our setup, follow the below commands:
+* Remove the `"${NODE_ECDSA_KEY_FILE_HOST}:/app/operator_keys/ecdsa_key.json:readonly"` mount from `docker-compose.yml` file.
+* Update the `NODE_ECDSA_KEY_FILE` in your `.env` file to be empty.
+* Update the `NODE_ECDSA_KEY_PASSWORD` in your `.env` file to be empty.
+* Update the `NODE_PUBLIC_IP_CHECK_INTERVAL` in your `.env` file to be `0` (This flag was used to check and update your IP onchain if your IP changes, so if your IP changes it's your responsibility to update).
+* Run your node normally using the `docker compose up -d` command.
+* Opt-in to EigenDA if not already opted in.


### PR DESCRIPTION
- Add readme to explain how to run node without access to operator keys.