### PR TITLE
remove the need of ecdsa key by default

### DIFF
--- a/holesky/.env.example
+++ b/holesky/.env.example
@@ -60,9 +60,14 @@ NODE_CHURNER_URL=churner-holesky.eigenda.xyz:443
 # If set to empty string, the IP address will be taken from the connection.
 # The rightmost value of the header will be used.
 NODE_CLIENT_IP_HEADER=x-real-ip
-# How often to check the public IP address of the node. Set this to 0 to disable
-# automatic IP address updating (if you have a stable IP address)
-NODE_PUBLIC_IP_CHECK_INTERVAL=10s
+
+# How often to check the public IP address of the node.
+# This is disabled by default since this required operator's
+# ecdsa key which we don't recommend giving access to the node
+# If for some reason you want this feature, you can use values like 5m, 10m, 1h etc.
+# If you enable it, makes sure your node have access to the ecdsa key
+# Follow this guidance to enable this feature: TODO(madhur): Add the link to the guidance
+NODE_PUBLIC_IP_CHECK_INTERVAL=0
 
 ###############################################################################
 ####### TODO: Operators please update below values for your node ##############

--- a/holesky/.env.example
+++ b/holesky/.env.example
@@ -89,7 +89,8 @@ NODE_DB_PATH_HOST=${EIGENDA_HOME}/db
 NODE_CACHE_PATH_HOST=${USER_HOME}/eigenda-operator-setup/resources/cache
 
 # TODO: Operators need to update this to their own keys
-NODE_ECDSA_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.ecdsa.key.json
+# Uncomment NODE_ECDSA_KEY_FILE_HOST if your need access to ecdsa key. This is generally not recommended
+# NODE_ECDSA_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.ecdsa.key.json
 NODE_BLS_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.bls.key.json
 
 # TODO: The ip provider service used to obtain a node's public IP [seeip (default), ipify)
@@ -97,5 +98,6 @@ NODE_PUBLIC_IP_PROVIDER=seeip
 
 # TODO: Operators need to add password to decrypt the above keys
 # If you have some special characters in password, make sure to use single quotes
-NODE_ECDSA_KEY_PASSWORD=''
+# Uncomment NODE_ECDSA_KEY_PASSWORD if your need access to ecdsa key. This is generally not recommended
+# NODE_ECDSA_KEY_PASSWORD=''
 NODE_BLS_KEY_PASSWORD=''

--- a/holesky/.env.example
+++ b/holesky/.env.example
@@ -62,7 +62,7 @@ NODE_CHURNER_URL=churner-holesky.eigenda.xyz:443
 NODE_CLIENT_IP_HEADER=x-real-ip
 
 # How often to check the public IP address of the node.
-# This is disabled by default since this required operator's
+# This is disabled by default since this requires operator's
 # ecdsa key which we don't recommend giving access to the node
 # If for some reason you want this feature, you can use values like 5m, 10m, 1h etc.
 # If you enable it, makes sure your node have access to the ecdsa key
@@ -94,7 +94,7 @@ NODE_DB_PATH_HOST=${EIGENDA_HOME}/db
 NODE_CACHE_PATH_HOST=${USER_HOME}/eigenda-operator-setup/resources/cache
 
 # TODO: Operators need to update this to their own keys
-# Uncomment NODE_ECDSA_KEY_FILE_HOST if your need access to ecdsa key. This is generally not recommended
+# Uncomment NODE_ECDSA_KEY_FILE_HOST if your node need access to ecdsa key. This is generally not recommended
 # NODE_ECDSA_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.ecdsa.key.json
 NODE_BLS_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.bls.key.json
 
@@ -103,6 +103,6 @@ NODE_PUBLIC_IP_PROVIDER=seeip
 
 # TODO: Operators need to add password to decrypt the above keys
 # If you have some special characters in password, make sure to use single quotes
-# Uncomment NODE_ECDSA_KEY_PASSWORD if your need access to ecdsa key. This is generally not recommended
+# Uncomment NODE_ECDSA_KEY_PASSWORD if your node need access to ecdsa key. This is generally not recommended
 # NODE_ECDSA_KEY_PASSWORD=''
 NODE_BLS_KEY_PASSWORD=''

--- a/holesky/docker-compose.yml
+++ b/holesky/docker-compose.yml
@@ -29,7 +29,8 @@ services:
     networks:
       - eigenda
     volumes:
-      - "${NODE_ECDSA_KEY_FILE_HOST}:/app/operator_keys/ecdsa_key.json:readonly"
+#      Uncomment the following line if you want Node to use ecdsa key. This is generally not recommended
+#      - "${NODE_ECDSA_KEY_FILE_HOST}:/app/operator_keys/ecdsa_key.json:readonly"
       - "${NODE_BLS_KEY_FILE_HOST}:/app/operator_keys/bls_key.json:readonly"
       - "${NODE_G1_PATH_HOST}:/app/g1.point:readonly"
       - "${NODE_G2_PATH_HOST}:/app/g2.point.powerOf2:readonly"

--- a/holesky/run.sh
+++ b/holesky/run.sh
@@ -3,6 +3,63 @@
 
 . ./.env
 
+# Initialize variables
+NODE_ECDSA_KEY_FILE_HOST=""
+NODE_ECDSA_KEY_PASSWORD=""
+OPERATION_TYPE=""
+QUORUMS=""
+
+# Loop through command-line arguments
+# shellcheck disable=SC2039
+while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+        --node-ecdsa-key-file-host)
+            NODE_ECDSA_KEY_FILE_HOST="$2"
+            shift
+            ;;
+        --node-ecdsa-key-password)
+            NODE_ECDSA_KEY_PASSWORD="$2"
+            shift
+            ;;
+        --operation-type)
+            OPERATION_TYPE="$2"
+            shift
+            ;;
+        --quorums)
+            QUORUMS="$2"
+            shift
+            ;;
+        *)  # Unknown flag
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Check if flags are provided
+if [ -z "$OPERATION_TYPE" ]; then
+    echo "--operation-type is required."
+    exit 1
+fi
+
+if [ "$OPERATION_TYPE" != "list-quorums" ] && [ -z "$NODE_ECDSA_KEY_FILE_HOST" ]; then
+    echo "--node-ecdsa-key-file-host is required."
+    exit 1
+fi
+
+if [ "$OPERATION_TYPE" != "list-quorums" ] && [ -z "$NODE_ECDSA_KEY_PASSWORD" ]; then
+    echo "--node-ecdsa-key-password is required."
+    exit 1
+fi
+
+if { [ "$OPERATION_TYPE" = "opt-in" ] || [ "$OPERATION_TYPE" = "opt-out" ]; } && [ -z "$QUORUMS" ] ; then
+    echo "--quorum is required for opt-in or opt-out operation."
+    exit 1
+fi
+
 socket="$NODE_HOSTNAME":"${NODE_DISPERSAL_PORT}"\;"${NODE_RETRIEVAL_PORT}"
 
 node_plugin_image="ghcr.io/layr-labs/eigenda/opr-nodeplugin:release-0.6.2"
@@ -45,7 +102,6 @@ listQuorums() {
   # we have to pass a dummy quorum-id-list as it is required by the plugin
   docker run --env-file .env \
     --rm \
-    --volume "${NODE_ECDSA_KEY_FILE_HOST}":/app/operator_keys/ecdsa_key.json \
     --volume "${NODE_BLS_KEY_FILE_HOST}":/app/operator_keys/bls_key.json \
     --volume "${NODE_LOG_PATH_HOST}":/app/logs:rw \
     "$node_plugin_image" \
@@ -71,23 +127,17 @@ updateSocket() {
     --quorum-id-list 0
 }
 
-if [ "$1" = "opt-in" ]; then
-  if [ -z "$2" ]; then
-    echo "Please provide quorum number (0/1/0,1)"
-    echo "Example Usage: ./run.sh opt-in 0"
-    exit 1
-  fi
-  optIn "$2"
-elif [ "$1" = "opt-out" ]; then
-  if [ -z "$2" ]; then
-    echo "Please provide quorum number (0/1/0,1)"
-    echo "Example Usage: ./run.sh opt-out 0"
-    exit 1
-  fi
-  optOut "$2"
-elif [ "$1" = "list-quorums" ]; then
+if [ "$OPERATION_TYPE" = "opt-in" ]; then
+  echo "Opting in"
+  optIn "$QUORUMS"
+elif [ "$OPERATION_TYPE" = "opt-out" ]; then
+  echo "Opting out"
+  optOut "$QUORUMS"
+elif [ "$OPERATION_TYPE" = "list-quorums" ]; then
+  echo "Listing quorums"
   listQuorums
-elif [ "$1" = "update-socket" ]; then
+elif [ "$OPERATION_TYPE" = "update-socket" ]; then
+  echo "Updating socket"
   updateSocket
 else
   echo "Invalid command"

--- a/holesky/run.sh
+++ b/holesky/run.sh
@@ -21,8 +21,7 @@ show_help() {
 }
 
 # Loop through command-line arguments
-# shellcheck disable=SC2039
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     key="$1"
 
     case $key in

--- a/holesky/run.sh
+++ b/holesky/run.sh
@@ -9,12 +9,27 @@ NODE_ECDSA_KEY_PASSWORD=""
 OPERATION_TYPE=""
 QUORUMS=""
 
+# Function to display usage information
+show_help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  -h, --help                            Display this help message"
+    echo "  --node-ecdsa-key-file-host <path>     Path to the node's ECDSA key file. Required for opt-in, opt-out and update-socket operations"
+    echo "  --node-ecdsa-key-password <password>  Password for the node's ECDSA key file. Required for opt-in, opt-out and update-socket operations"
+    echo "  --operation-type <operation>          Operation type (opt-in, opt-out, list-quorums, update-socket)"
+    echo "  --quorums <quorums>                   Quorum IDs to opt-in or opt-out"
+}
+
 # Loop through command-line arguments
 # shellcheck disable=SC2039
 while [[ $# -gt 0 ]]; do
     key="$1"
 
     case $key in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
         --node-ecdsa-key-file-host)
             NODE_ECDSA_KEY_FILE_HOST="$2"
             shift
@@ -105,7 +120,6 @@ listQuorums() {
     --volume "${NODE_BLS_KEY_FILE_HOST}":/app/operator_keys/bls_key.json \
     --volume "${NODE_LOG_PATH_HOST}":/app/logs:rw \
     "$node_plugin_image" \
-    --ecdsa-key-password "$NODE_ECDSA_KEY_PASSWORD" \
     --bls-key-password "$NODE_BLS_KEY_PASSWORD" \
     --socket "$socket" \
     --operation list-quorums \

--- a/holesky/run.sh
+++ b/holesky/run.sh
@@ -47,6 +47,7 @@ while [ $# -gt 0 ]; do
             ;;
         *)  # Unknown flag
             echo "Unknown option: $1"
+            show_help
             exit 1
             ;;
     esac
@@ -56,21 +57,25 @@ done
 # Check if flags are provided
 if [ -z "$OPERATION_TYPE" ]; then
     echo "--operation-type is required."
+    show_help
     exit 1
 fi
 
 if [ "$OPERATION_TYPE" != "list-quorums" ] && [ -z "$NODE_ECDSA_KEY_FILE_HOST" ]; then
     echo "--node-ecdsa-key-file-host is required."
+    show_help
     exit 1
 fi
 
 if [ "$OPERATION_TYPE" != "list-quorums" ] && [ -z "$NODE_ECDSA_KEY_PASSWORD" ]; then
     echo "--node-ecdsa-key-password is required."
+    show_help
     exit 1
 fi
 
 if { [ "$OPERATION_TYPE" = "opt-in" ] || [ "$OPERATION_TYPE" = "opt-out" ]; } && [ -z "$QUORUMS" ] ; then
     echo "--quorum is required for opt-in or opt-out operation."
+    show_help
     exit 1
 fi
 
@@ -154,4 +159,5 @@ elif [ "$OPERATION_TYPE" = "update-socket" ]; then
   updateSocket
 else
   echo "Invalid command"
+  show_helps
 fi


### PR DESCRIPTION
- This PR removes the need of ECDSA key while running the node by default. Operator can still choose to use but there will be extra steps required and would generally be not recommended

This PR also changes interfaces for all operations. 

Note: Same `.env` file is being used for these operations and running node.  Even though only few variables are needed from the `.env` files for `run.sh` script, to have minimal change I want to keep `.env` for this too. But this is debatable if we want to remove `.env` file for `run.sh` we have to make everything as argument and also need to make sure `nodeplugin` doesn't require any unnecessary fields from `.env` file

####  Opt In
```
./run.sh \
  --operation-type opt-in \
  --node-ecdsa-key-file-host /path/to/ecdsa/file  \
  --node-ecdsa-key-password password \
  --quorums 0
```

####  Opt out
```
./run.sh \
  --operation-type opt-out \
  --node-ecdsa-key-file-host /path/to/ecdsa/file  \
  --node-ecdsa-key-password password \
  --quorums 0
```

####  List Quorums
```
./run.sh --operation-type list-quorums
```

####  Update socket
```
./run.sh \
  --operation-type update-socket \
  --node-ecdsa-key-file-host /path/to/ecdsa/file  \
  --node-ecdsa-key-password password
```

TODO
- [x] Test in the preprod
- [ ] Blocked by https://github.com/Layr-Labs/eigenda/pull/522 for ecdsa key requirement