### PR TITLE
Define TCP max window 16MB

### DIFF
--- a/holesky/README.md
+++ b/holesky/README.md
@@ -1,3 +1,3 @@
 # Holesky
 
-Head over to our [EigenDA operator guides](https://docs.eigenlayer.xyz/eigenda/operator-guides/overview) for installation instructions and more details.
+Head over to our [EigenDA operator guide](https://docs.eigenlayer.xyz/eigenda/operator-guides/overview) for installation instructions and more details.

--- a/holesky/README.md
+++ b/holesky/README.md
@@ -1,3 +1,3 @@
 # Holesky
 
-Head over to our [EigenDA operator guide](https://docs.eigenlayer.xyz/eigenda/operator-guides/overview) for installation instructions and more details.
+Head over to our [EigenDA operator guides](https://docs.eigenlayer.xyz/eigenda/operator-guides/overview) for installation instructions and more details.

--- a/holesky/docker-compose.yml
+++ b/holesky/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       - .env
     restart: unless-stopped
   da-node:
+    sysctls:
+      net.ipv4.tcp_window_scaling: 1
+      net.ipv4.tcp_rmem: "4096 131072 16000000"
     env_file:
       - .env
     container_name: ${MAIN_SERVICE_NAME}

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       - .env
     restart: unless-stopped
   da-node:
+    sysctls:
+      net.ipv4.tcp_window_scaling: 1
+      net.ipv4.tcp_rmem: "4096 131072 16000000"
     env_file:
       - .env
     container_name: ${MAIN_SERVICE_NAME}


### PR DESCRIPTION
Experimental TCP max window settings

You can determine current TCP window setting via
```
> cat /proc/sys/net/ipv4/tcp_rmem
4096    131072  6291456
```
This output show `6.2MB` max window 

According to https://www.ibm.com/docs/en/linux-on-systems?topic=tuning-tcpip-ipv4-settings#wkvm_tune_tcpip__title__7 10G nic should be able to handle 16MB max window (or more)

To change `tcp_rmem` outside of docker, run `sudo sysctl -w net.ipv4.tcp_rmem='4096 131072 16000000'`

These values are not hard enforced and the kernel might choose something lower.