### PR TITLE
chore: add note to use docker container name

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -72,7 +72,9 @@ scrape_configs:
     scrape_interval: 5s
 
     static_configs:
-      # Point to the same endpoint that EigenDA is publishing on
+      # Point to the same endpoint that EigenDA is publishing on.
+      # If using the sample docker-compose.yml for EigenDA, use the name of the
+      # container instead of localhost (e.g. da-node:9092)
       - targets: ["localhost:<NODE_METRICS_PORT>"]
 ```
 


### PR DESCRIPTION
When using the sample docker-compose.yml for EigenDA and the docker-compose.yml in this metrics folder the target host for Prometheus should be the eigenda container name. This adds a note to the sample env in the readme to help debug if metrics aren't working.