### PR TITLE
Update testnet .env.example for 0.8.6-rc.0

### DIFF
--- a/holesky/.env.example
+++ b/holesky/.env.example
@@ -1,4 +1,4 @@
-MAIN_SERVICE_IMAGE=ghcr.io/layr-labs/eigenda/opr-node:0.8.5-rc.0
+MAIN_SERVICE_IMAGE=ghcr.io/layr-labs/eigenda/opr-node:0.8.6-rc.0
 NETWORK_NAME=eigenda-network
 MAIN_SERVICE_NAME=eigenda-native-node
 
@@ -95,6 +95,11 @@ NODE_CACHE_PATH_HOST=${USER_HOME}/eigenda-operator-setup/resources/cache
 # TODO: Operators need to update this to their own keys
 NODE_ECDSA_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.ecdsa.key.json
 NODE_BLS_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.bls.key.json
+
+# TODO: Uncomment and update if using remote BLS signer https://github.com/Layr-Labs/cerberus
+#NODE_BLS_REMOTE_SIGNER_ENABLED=true
+#NODE_BLS_REMOTE_SIGNER_URL=<host:port>
+#NODE_BLS_PUBLIC_KEY_HEX=<public key registered with remote signer>
 
 # TODO: The ip provider service used to obtain a node's public IP [seeip (default), ipify)
 NODE_PUBLIC_IP_PROVIDER=seeip


### PR DESCRIPTION
Adds commented out env variable for new remote BLS signer support