### PR TITLE
chore: add the API key flag to remote signer for updated signer API

### DIFF
--- a/holesky/.env.example
+++ b/holesky/.env.example
@@ -100,6 +100,7 @@ NODE_BLS_KEY_FILE_HOST=${EIGENLAYER_HOME}/operator_keys/opr.bls.key.json
 #NODE_BLS_SIGNER_CERT_FILE=/app/cerberus/cerberus.crt # DO NOT CHANGE THIS
 #NODE_BLS_REMOTE_SIGNER_ENABLED=true
 #NODE_BLS_REMOTE_SIGNER_URL=<host:port>
+#NODE_BLS_SIGNER_API_KEY=<api key for remote signer>
 #NODE_BLS_PUBLIC_KEY_HEX=<public key registered with remote signer>
 #NODE_BLS_SIGNER_CERT_FILE_HOST=<path to cert file on host>
 


### PR DESCRIPTION
Add BLS signer API key for using Cerberus. 
This should be merged with latest eigenda release!