### PR TITLE
Enable runtime mode flags in the configs

### DIFF
--- a/holesky/.env.example
+++ b/holesky/.env.example
@@ -13,6 +13,9 @@ NODE_NUM_WORKERS=1
 NODE_DISPERSAL_PORT=32005
 NODE_V2_DISPERSAL_PORT=32006
 
+# This flag defines a runtime mode. Acceptable inputs are v1-only, v2-only, v1-and-v2
+NODE_RUNTIME_MODE=v1-and-v2
+
 # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
 # In future release, this will be removed
 NODE_QUORUM_ID_LIST=0

--- a/mainnet/.env.example
+++ b/mainnet/.env.example
@@ -13,6 +13,9 @@ NODE_NUM_WORKERS=1
 NODE_DISPERSAL_PORT=32005
 NODE_V2_DISPERSAL_PORT=32006
 
+# This flag defines a runtime mode. Acceptable inputs are v1-only, v2-only, v1-and-v2
+NODE_RUNTIME_MODE=v1-and-v2
+
 # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
 # In future release, this will be removed
 NODE_QUORUM_ID_LIST=0


### PR DESCRIPTION
- Adds NODE_RUNTIME_MODE to verify the runtime mode (v1-only, v2-only, v1-and-v2)