### PR TITLE
Remove legacy V1 config for v2.7.0 release

### DIFF
--- a/hoodi/.env.example
+++ b/hoodi/.env.example
@@ -1,4 +1,4 @@
-MAIN_SERVICE_IMAGE=ghcr.io/layr-labs/eigenda/opr-node:2.6.0
+MAIN_SERVICE_IMAGE=ghcr.io/layr-labs/eigenda/opr-node:2.7.0
 NETWORK_NAME=eigenda-network
 MAIN_SERVICE_NAME=eigenda-native-node
 
@@ -10,28 +10,21 @@ NODE_PRIVATE_KEY=
 NODE_EXPIRATION_POLL_INTERVAL=180
 NODE_CACHE_ENCODED_BLOBS=true
 NODE_NUM_WORKERS=1
-NODE_DISPERSAL_PORT=32005
 NODE_V2_DISPERSAL_PORT=32006
-
-# This flag defines a runtime mode. Acceptable inputs are v1-only, v2-only, v1-and-v2
-NODE_RUNTIME_MODE=v1-and-v2
 
 # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
 # In future release, this will be removed
 NODE_QUORUM_ID_LIST=0
 
 NODE_VERBOSE=true
-NODE_RETRIEVAL_PORT=32004
 NODE_V2_RETRIEVAL_PORT=32007
 NODE_TIMEOUT=20s
 NODE_SRS_ORDER=268435456
 NODE_SRS_LOAD=8388608
 
-# If you are using a reverse proxy in a shared network space, the reverse proxy should listen at $NODE_DISPERSAL_PORT
-# and forward the traffic to $NODE_INTERNAL_DISPERSAL_PORT, and similarly for retrieval. The DA node will register the
-# $NODE_DISPERSAL_PORT port on the chain and listen for the reverse proxy at $NODE_INTERNAL_DISPERSAL_PORT.
-NODE_INTERNAL_DISPERSAL_PORT=${NODE_DISPERSAL_PORT}
-NODE_INTERNAL_RETRIEVAL_PORT=${NODE_RETRIEVAL_PORT}
+# If you are using a reverse proxy in a shared network space, the reverse proxy should listen at $NODE_V2_DISPERSAL_PORT
+# and forward the traffic to $NODE_INTERNAL_V2_DISPERSAL_PORT, and similarly for retrieval. The DA node will register the
+# $NODE_V2_DISPERSAL_PORT port on the chain and listen for the reverse proxy at $NODE_INTERNAL_V2_DISPERSAL_PORT.
 NODE_INTERNAL_V2_DISPERSAL_PORT=${NODE_V2_DISPERSAL_PORT}
 NODE_INTERNAL_V2_RETRIEVAL_PORT=${NODE_V2_RETRIEVAL_PORT}
 

--- a/hoodi/README.md
+++ b/hoodi/README.md
@@ -4,15 +4,6 @@ Head over to our [EigenDA operator guides](https://docs.eigencloud.xyz/products/
 
 ## V2 Environment Variable Reference
 
-### `NODE_RUNTIME_MODE`
-This environment variable will be used to determine the runtime mode of the EigenDA node.
-
-- `v1-and-v2`: The node will serve both v1 and v2 traffic (default)
-- `v2-only`: The node will serve v2 traffic only
-- `v1-only`: The node will serve v1 traffic only
-
-The `v1-only` & `v2-only` modes are intended for isolating traffic to separate validator instances - where 1 instance serves v1 traffic and a second instance serves v2 traffic.
-
 ### `NODE_V2_DISPERSAL_PORT`
 <ins>Operators must publically expose this port</ins>. This port will be used to listen for dispersal requests from the EigenDA v2 API. IP whitelisting is no longer required with v2.
 
@@ -25,6 +16,29 @@ This port is intended for Nginx reverse proxy use.
 ### `NODE_INTERNAL_V2_RETRIEVAL_PORT`
 This port is intended for Nginx reverse proxy use.
 
+## V1 Deprecation
+As of `v2.7.0` V1 support has been removed from the node client
+
+### New optional flags
+```
+--node.delete-v1-data                                 When enabled, deletes any existing v1 data on node startup [$NODE_DELETE_V1_DATA]
+```
+
+### Removed flags
+```
+--node.dispersal-port value                           Port at which node registers to listen for dispersal calls [$NODE_DISPERSAL_PORT]
+--node.retrieval-port value                           Port at which node registers to listen for retrieval calls [$NODE_RETRIEVAL_PORT]
+--node.internal-dispersal-port value                  Port at which node listens for dispersal calls (used when node is behind NGINX) [$NODE_INTERNAL_DISPERSAL_PORT]
+--node.internal-retrieval-port value                  Port at which node listens for retrieval calls (used when node is behind NGINX) [$NODE_INTERNAL_RETRIEVAL_PORT]
+--node.runtime-mode value                             Node runtime mode (v1-and-v2 (default), v1-only, or v2-only) (default: "v1-and-v2") [$NODE_RUNTIME_MODE]
+--node.disable-dispersal-authentication               Disable authentication for StoreChunks() calls from the disperser [$NODE_DISABLE_DISPERSAL_AUTHENTICATION]
+--node.leveldb-disable-seeks-compaction-v1            Disable seeks compaction for LevelDB for v1 [$NODE_LEVELDB_DISABLE_SEEKS_COMPACTION_V1]
+--node.leveldb-enable-sync-writes-v1                  Enable sync writes for LevelDB for v1 [$NODE_LEVELDB_ENABLE_SYNC_WRITES_V1]
+--node.enable-payment-validation                      Whether the validator should perform payment validation. Temporary flag that will be removed once the new payments system is fully in place. default: true. [$NODE_ENABLE_PAYMENT_VALIDATION]
+--node.on-demand-meter-refresh-interval value         Interval for refreshing on-demand global rate limit parameters from the payment vault. (default: 5m0s) [$NODE_ON_DEMAND_METER_REFRESH_INTERVAL]
+--node.on-demand-meter-fuzz-factor value              Multiplier applied to on-chain on-demand throughput before enforcement; >1.0 allows a small buffer. (default: 1.1) [$NODE_ON_DEMAND_METER_FUZZ_FACTOR]
+--chain.retry-delay-increment value                   Time unit for linear retry delay. For instance, if the retries count is 2 and retry delay is 1 second, then 0 second is waited for the first call; 1 seconds are waited before the next retry; 2 seconds are waited for the second retry; if the call failed, the total waited time for retry is 3 seconds. If the retry delay is 0 second, the total waited time for retry is 0 second. (default: 0s) [$NODE_RETRY_DELAY_INCREMENT]
+```
 
 ## Advanced - Multi drive support for V2 LittDB
 

--- a/hoodi/docker-compose.yml
+++ b/hoodi/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   reverse-proxy:
     image: nginx:latest
     ports:
-      - "${NODE_RETRIEVAL_PORT}:${NODE_RETRIEVAL_PORT}"
       - "${NODE_V2_RETRIEVAL_PORT}:${NODE_V2_RETRIEVAL_PORT}"
       - "${NODE_API_PORT}:${NODE_API_PORT}"
     volumes:
@@ -25,7 +24,6 @@ services:
     container_name: ${MAIN_SERVICE_NAME}
     image: ${MAIN_SERVICE_IMAGE}
     ports:
-      - "${NODE_DISPERSAL_PORT}:${NODE_INTERNAL_DISPERSAL_PORT}"
       - "${NODE_V2_DISPERSAL_PORT}:${NODE_INTERNAL_V2_DISPERSAL_PORT}"
       - "${NODE_METRICS_PORT}:${NODE_METRICS_PORT}"
     networks:

--- a/hoodi/run.sh
+++ b/hoodi/run.sh
@@ -3,7 +3,7 @@
 
 . ./.env
 
-node_plugin_image="ghcr.io/layr-labs/eigenda/opr-nodeplugin:2.6.0"
+node_plugin_image="ghcr.io/layr-labs/eigenda/opr-nodeplugin:2.7.0"
 
 # Check if V2 ports are defined
 if [ -z "$NODE_V2_DISPERSAL_PORT" ]; then

--- a/hoodi/run.sh
+++ b/hoodi/run.sh
@@ -16,7 +16,7 @@ if [ -z "$NODE_V2_DISPERSAL_PORT" ] || [ -z "$NODE_V2_RETRIEVAL_PORT" ]; then
   echo "ERROR: Please update your .env file. See .env.example for reference."
     exit 1
 fi
-socket="$NODE_HOSTNAME":"${NODE_DISPERSAL_PORT}"\;"${NODE_RETRIEVAL_PORT}"\;"${NODE_V2_DISPERSAL_PORT}"\;"${NODE_V2_RETRIEVAL_PORT}"
+socket="$NODE_HOSTNAME":"${NODE_V2_DISPERSAL_PORT}"\;"${NODE_V2_RETRIEVAL_PORT}"\;"${NODE_V2_DISPERSAL_PORT}"\;"${NODE_V2_RETRIEVAL_PORT}"
 
 # In all commands, We have to explicitly set the password again here because
 # when docker run loads the `.env` file, it keeps the quotes around the password

--- a/mainnet/.env.example
+++ b/mainnet/.env.example
@@ -1,4 +1,4 @@
-MAIN_SERVICE_IMAGE=ghcr.io/layr-labs/eigenda/opr-node:2.6.0
+MAIN_SERVICE_IMAGE=ghcr.io/layr-labs/eigenda/opr-node:2.7.0
 NETWORK_NAME=eigenda-network
 MAIN_SERVICE_NAME=eigenda-native-node
 
@@ -10,28 +10,21 @@ NODE_PRIVATE_KEY=
 NODE_EXPIRATION_POLL_INTERVAL=180
 NODE_CACHE_ENCODED_BLOBS=true
 NODE_NUM_WORKERS=1
-NODE_DISPERSAL_PORT=32005
 NODE_V2_DISPERSAL_PORT=32006
-
-# This flag defines a runtime mode. Acceptable inputs are v1-only, v2-only, v1-and-v2
-NODE_RUNTIME_MODE=v1-and-v2
 
 # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
 # In future release, this will be removed
 NODE_QUORUM_ID_LIST=0
 
 NODE_VERBOSE=true
-NODE_RETRIEVAL_PORT=32004
 NODE_V2_RETRIEVAL_PORT=32007
 NODE_TIMEOUT=20s
 NODE_SRS_ORDER=268435456
 NODE_SRS_LOAD=8388608
 
-# If you are using a reverse proxy in a shared network space, the reverse proxy should listen at $NODE_DISPERSAL_PORT
-# and forward the traffic to $NODE_INTERNAL_DISPERSAL_PORT, and similarly for retrieval. The DA node will register the
-# $NODE_DISPERSAL_PORT port on the chain and listen for the reverse proxy at $NODE_INTERNAL_DISPERSAL_PORT.
-NODE_INTERNAL_DISPERSAL_PORT=${NODE_DISPERSAL_PORT}
-NODE_INTERNAL_RETRIEVAL_PORT=${NODE_RETRIEVAL_PORT}
+# If you are using a reverse proxy in a shared network space, the reverse proxy should listen at $NODE_V2_DISPERSAL_PORT
+# and forward the traffic to $NODE_INTERNAL_V2_DISPERSAL_PORT, and similarly for retrieval. The DA node will register the
+# $NODE_V2_DISPERSAL_PORT port on the chain and listen for the reverse proxy at $NODE_INTERNAL_V2_DISPERSAL_PORT.
 NODE_INTERNAL_V2_DISPERSAL_PORT=${NODE_V2_DISPERSAL_PORT}
 NODE_INTERNAL_V2_RETRIEVAL_PORT=${NODE_V2_RETRIEVAL_PORT}
 

--- a/mainnet/README.md
+++ b/mainnet/README.md
@@ -2,72 +2,7 @@
 
 Head over to our [EigenDA operator guides](https://docs.eigencloud.xyz/products/eigenda/operator-guides/overview) for installation instructions and more details.
 
-## Blazar (EigenDA V2) Migration
-Operators running node version `<=v0.8.6` will need to define new v2 specific environment variables, expose 2 new ports, and update their socket registration as part of the migration to v2.
-
-## Migration Steps
-### 1. Update `.env` with v2 specific environment variables
-```
-NODE_V2_RUNTIME_MODE=v1-and-v2
-
-NODE_V2_DISPERSAL_PORT=32006
-NODE_V2_RETRIEVAL_PORT=32007
-
-# Internal ports for Nginx reverse proxy
-NODE_INTERNAL_V2_DISPERSAL_PORT=${NODE_V2_DISPERSAL_PORT}
-NODE_INTERNAL_V2_RETRIEVAL_PORT=${NODE_V2_RETRIEVAL_PORT}
-```
-
-### 2. Update `MAIN_SERVICE_IMAGE`
-```
-MAIN_SERVICE_IMAGE=ghcr.io/layr-labs/eigenda/opr-node:2.6.0
-```
-
-### 3. Update socket registration
-EigenDA v2 adds new ports to the socket registration. Socket registration update is required to receive v2 traffic.
-
-Ensure that you are using the latest version of the [eigenda-operator-setup](https://github.com/Layr-Labs/eigenda-operator-setup/releases) before updating the socket.
-```
-(eigenda-operator-setup) > ./run.sh update-socket
-You are about to update your socket to: 23.93.87.155:32005;32004;32006;32007
-Confirm? [Y/n]
-```
-
-### 4. Restart the node and monitor for reachability checks
-The node will check reachability of v1 & v2 sockets. If reachability checks are failing, check that the new ports are open and accessible.
-```
-Feb 20 19:47:07.861 INF node/node.go:743 Reachability check v1 - dispersal socket ONLINE component=Node status="node.Dispersal is available" socket=operator.eigenda.xyz:32001
-Feb 20 19:47:07.861 INF node/node.go:750 Reachability check v1 - retrieval socket ONLINE component=Node status="node.Retrieval is available" socket=operator.eigenda.xyz:32002
-Feb 20 19:47:07.867 INF node/node.go:743 Reachability check v2 - dispersal socket ONLINE component=Node status="validator.Dispersal is available" socket=operator.eigenda.xyz:32003
-Feb 20 19:47:07.867 INF node/node.go:750 Reachability check v2 - retrieval socket ONLINE component=Node status="validator.Retrieval is available" socket=operator.eigenda.xyz:32005
-```
-
-### 5. Confirm v2 StoreChunks requests are being served
-```
-Feb 20 19:50:36.741 INF grpc/server_v2.go:140 new StoreChunks request batchHeaderHash=873ac1c7faeec0f1e5c886142d0b364a94b3e906f1b4b4f1b0466a5f79cecefb numBlobs=14 referenceBlockNumber=3393054
-Feb 20 19:50:41.765 INF grpc/server_v2.go:140 new StoreChunks request batchHeaderHash=76873d64609d50aaf90e1c435c9278c588f1a174a4c0b4a721438a7d44bb2f1e numBlobs=18 referenceBlockNumber=3393054
-Feb 20 19:50:46.760 INF grpc/server_v2.go:140 new StoreChunks request batchHeaderHash=8182f31c9b58e04f0a09dfbf1634a73e47a660b441f65c7a35ef9e7afd064493 numBlobs=16 referenceBlockNumber=3393054
-
-```
-
-## V2 Remote BLS Signer API Migration
-__Breaking Change:__ With the release of EigenDA Blazar (v2), the the node software has been upgraded to use the latest [cerberus](https://github.com/Layr-Labs/cerberus) remote BLS signer release.
-
-This change requires the operator to define the `NODE_BLS_SIGNER_API_KEY` environment variable.
-
-Follow the steps from the [cerberus setup guide](https://github.com/Layr-Labs/cerberus?tab=readme-ov-file#remote-signer-implementation-of-cerberus-api) to create an API key.
-
-
 ## V2 Environment Variable Reference
-
-### `NODE_RUNTIME_MODE`
-This environment variable will be used to determine the runtime mode of the EigenDA node.
-
-- `v1-and-v2`: The node will serve both v1 and v2 traffic (default)
-- `v2-only`: The node will serve v2 traffic only
-- `v1-only`: The node will serve v1 traffic only
-
-The `v1-only` & `v2-only` modes are intended for isolating traffic to separate validator instances - where 1 instance serves v1 traffic and a second instance serves v2 traffic.
 
 ### `NODE_V2_DISPERSAL_PORT`
 <ins>Operators must publically expose this port</ins>. This port will be used to listen for dispersal requests from the EigenDA v2 API. IP whitelisting is no longer required with v2.
@@ -81,6 +16,29 @@ This port is intended for Nginx reverse proxy use.
 ### `NODE_INTERNAL_V2_RETRIEVAL_PORT`
 This port is intended for Nginx reverse proxy use.
 
+## V1 Deprecation
+As of `v2.7.0` V1 support has been removed from the node client
+
+### New optional flags
+```
+--node.delete-v1-data                                 When enabled, deletes any existing v1 data on node startup [$NODE_DELETE_V1_DATA]
+```
+
+### Removed flags
+```
+--node.dispersal-port value                           Port at which node registers to listen for dispersal calls [$NODE_DISPERSAL_PORT]
+--node.retrieval-port value                           Port at which node registers to listen for retrieval calls [$NODE_RETRIEVAL_PORT]
+--node.internal-dispersal-port value                  Port at which node listens for dispersal calls (used when node is behind NGINX) [$NODE_INTERNAL_DISPERSAL_PORT]
+--node.internal-retrieval-port value                  Port at which node listens for retrieval calls (used when node is behind NGINX) [$NODE_INTERNAL_RETRIEVAL_PORT]
+--node.runtime-mode value                             Node runtime mode (v1-and-v2 (default), v1-only, or v2-only) (default: "v1-and-v2") [$NODE_RUNTIME_MODE]
+--node.disable-dispersal-authentication               Disable authentication for StoreChunks() calls from the disperser [$NODE_DISABLE_DISPERSAL_AUTHENTICATION]
+--node.leveldb-disable-seeks-compaction-v1            Disable seeks compaction for LevelDB for v1 [$NODE_LEVELDB_DISABLE_SEEKS_COMPACTION_V1]
+--node.leveldb-enable-sync-writes-v1                  Enable sync writes for LevelDB for v1 [$NODE_LEVELDB_ENABLE_SYNC_WRITES_V1]
+--node.enable-payment-validation                      Whether the validator should perform payment validation. Temporary flag that will be removed once the new payments system is fully in place. default: true. [$NODE_ENABLE_PAYMENT_VALIDATION]
+--node.on-demand-meter-refresh-interval value         Interval for refreshing on-demand global rate limit parameters from the payment vault. (default: 5m0s) [$NODE_ON_DEMAND_METER_REFRESH_INTERVAL]
+--node.on-demand-meter-fuzz-factor value              Multiplier applied to on-chain on-demand throughput before enforcement; >1.0 allows a small buffer. (default: 1.1) [$NODE_ON_DEMAND_METER_FUZZ_FACTOR]
+--chain.retry-delay-increment value                   Time unit for linear retry delay. For instance, if the retries count is 2 and retry delay is 1 second, then 0 second is waited for the first call; 1 seconds are waited before the next retry; 2 seconds are waited for the second retry; if the call failed, the total waited time for retry is 3 seconds. If the retry delay is 0 second, the total waited time for retry is 0 second. (default: 0s) [$NODE_RETRY_DELAY_INCREMENT]
+```
 
 ## Advanced - Multi drive support for V2 LittDB
 

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   reverse-proxy:
     image: nginx:latest
     ports:
-      - "${NODE_RETRIEVAL_PORT}:${NODE_RETRIEVAL_PORT}"
       - "${NODE_V2_RETRIEVAL_PORT}:${NODE_V2_RETRIEVAL_PORT}"
       - "${NODE_API_PORT}:${NODE_API_PORT}"
     volumes:
@@ -25,7 +24,6 @@ services:
     container_name: ${MAIN_SERVICE_NAME}
     image: ${MAIN_SERVICE_IMAGE}
     ports:
-      - "${NODE_DISPERSAL_PORT}:${NODE_INTERNAL_DISPERSAL_PORT}"
       - "${NODE_V2_DISPERSAL_PORT}:${NODE_INTERNAL_V2_DISPERSAL_PORT}"
       - "${NODE_METRICS_PORT}:${NODE_METRICS_PORT}"
     networks:

--- a/mainnet/run.sh
+++ b/mainnet/run.sh
@@ -3,7 +3,7 @@
 
 . ./.env
 
-node_plugin_image="ghcr.io/layr-labs/eigenda/opr-nodeplugin:2.6.0"
+node_plugin_image="ghcr.io/layr-labs/eigenda/opr-nodeplugin:2.7.0"
 
 # Check if V2 ports are defined
 if [ -z "$NODE_V2_DISPERSAL_PORT" ]; then
@@ -16,7 +16,7 @@ if [ -z "$NODE_V2_DISPERSAL_PORT" ] || [ -z "$NODE_V2_RETRIEVAL_PORT" ]; then
   echo "ERROR: Please update your .env file. See .env.example for reference."
     exit 1
 fi
-socket="$NODE_HOSTNAME":"${NODE_DISPERSAL_PORT}"\;"${NODE_RETRIEVAL_PORT}"\;"${NODE_V2_DISPERSAL_PORT}"\;"${NODE_V2_RETRIEVAL_PORT}"
+socket="$NODE_HOSTNAME":"${NODE_V2_DISPERSAL_PORT}"\;"${NODE_V2_RETRIEVAL_PORT}"\;"${NODE_V2_DISPERSAL_PORT}"\;"${NODE_V2_RETRIEVAL_PORT}"
 
 # In all commands, We have to explicitly set the password again here because
 # when docker run loads the `.env` file, it keeps the quotes around the password

--- a/resources/rate-limit-nginx.conf
+++ b/resources/rate-limit-nginx.conf
@@ -1,23 +1,6 @@
 limit_req_zone $binary_remote_addr zone=ip:10m rate=${REQUEST_LIMIT};
 
 server {
-    listen ${NODE_RETRIEVAL_PORT};
-
-    client_max_body_size 1M;
-
-    http2 on;
-
-    location / {
-        limit_req zone=ip burst=${BURST_LIMIT} nodelay;
-        limit_req_status 429;
-
-        grpc_set_header X-Real-IP $remote_addr;
-
-        grpc_pass grpc://${NODE_HOST}:${NODE_INTERNAL_RETRIEVAL_PORT};
-    }
-}
-
-server {
     listen ${NODE_V2_RETRIEVAL_PORT};
 
     client_max_body_size 1M;


### PR DESCRIPTION
## V1 Deprecation
As of `v2.7.0` V1 support has been removed from the node client

### New optional flags
```
--node.delete-v1-data                                 When enabled, deletes any existing v1 data on node startup [$NODE_DELETE_V1_DATA]
```

### Removed flags
```
--node.dispersal-port value                           Port at which node registers to listen for dispersal calls [$NODE_DISPERSAL_PORT]
--node.retrieval-port value                           Port at which node registers to listen for retrieval calls [$NODE_RETRIEVAL_PORT]
--node.internal-dispersal-port value                  Port at which node listens for dispersal calls (used when node is behind NGINX) [$NODE_INTERNAL_DISPERSAL_PORT]
--node.internal-retrieval-port value                  Port at which node listens for retrieval calls (used when node is behind NGINX) [$NODE_INTERNAL_RETRIEVAL_PORT]
--node.runtime-mode value                             Node runtime mode (v1-and-v2 (default), v1-only, or v2-only) (default: "v1-and-v2") [$NODE_RUNTIME_MODE]
--node.disable-dispersal-authentication               Disable authentication for StoreChunks() calls from the disperser [$NODE_DISABLE_DISPERSAL_AUTHENTICATION]
--node.leveldb-disable-seeks-compaction-v1            Disable seeks compaction for LevelDB for v1 [$NODE_LEVELDB_DISABLE_SEEKS_COMPACTION_V1]
--node.leveldb-enable-sync-writes-v1                  Enable sync writes for LevelDB for v1 [$NODE_LEVELDB_ENABLE_SYNC_WRITES_V1]
--node.enable-payment-validation                      Whether the validator should perform payment validation. Temporary flag that will be removed once the new payments system is fully in place. default: true. [$
NODE_ENABLE_PAYMENT_VALIDATION]
```